### PR TITLE
Fix typos and mathematical errors in Module 3 slides

### DIFF
--- a/acs-3-7-1-control.tex
+++ b/acs-3-7-1-control.tex
@@ -31,7 +31,7 @@ The PID controller is composed of three terms:
 
 \begin{frame}{Control without a model}
 \begin{itemize}
-\item Rather using a full state feedback controller based on a prediction of the future state of a system using a mathematical model, the PID controller uses linear extrapolation of the measured output for control
+\item Rather than using a full state feedback controller based on a prediction of the future state of a system using a mathematical model, the PID controller uses linear extrapolation of the measured output for control
 \item PID controllers are ubiquitous in industrial applications due to their wide applicability, ease of implementation, and avoidance of using a model
 \end{itemize}
 \end{frame}

--- a/acs-3-7-2-simple.tex
+++ b/acs-3-7-2-simple.tex
@@ -32,7 +32,7 @@
 	\item Any stable system can be modelled by a static system if its inputs are sufficiently slow, which approximates the transfer function by a constant 
 	\[K=P(0)\]
 	\item Using integral control, the controller is $K\tfrac{k_i}{s}$ with closed loop characteristic polynomial $s+Kk_i$
-	\item Specifying the performance of the controlled system by the desired time constant $T_{cl}$ of the closed loopn system, we have
+	\item Specifying the performance of the controlled system by the desired time constant $T_{cl}$ of the closed loop system, we have
 	\[k_i = \frac{1}{T_c P(0)}\]
 	\item A reasonable criterion for the process transfer function to be well approximated by a constant is that the average residence time $T_{ar}=\tfrac{-P'(0)}{P(0)}$ satisfies $T_{ar}<T_{cl}$
 \end{itemize}
@@ -59,7 +59,7 @@
 \item Consider a first-order system with transfer function 
 \[P(s) = \frac{b}{s+a}\]
 \item Comparing the desired and closed loop characteristic polynomials with a PI controller
-\[s^2+a_1s+a_2 = s^2 (a_bk_p)s+bk_i\]
+\[s^2+a_1s+a_2 = s^2+(a+bk_p)s+bk_i\]
 \item We may therefore assign arbitrary values of the closed loop poles via PI control
 \[k_p=\frac{a_1-a}{b}, \quad k_i = \frac{a_2}{b}\]
 \end{itemize}

--- a/acs-3-7-3-pid.tex
+++ b/acs-3-7-3-pid.tex
@@ -24,7 +24,7 @@
 		\item Designers and users of control systems frequently need to adjust parameters to achieve some desired behaviour
 		\item There are many, many ways to do this and one conventional framework is to model the system and then follow the design process outlined previously
 		\item For complicated, high-dimensional, nonlinear systems this can often be a tedious process
-		\item The PID controller has very few parameters and due to its simplicity may be preferrable in these challenging settings
+		\item The PID controller has very few parameters and due to its simplicity may be preferable in these challenging settings
 		\item Empirical tuning laws based on real systems have been developed for the adjustment of control parameters
 	\end{itemize}
 \end{frame}
@@ -87,7 +87,7 @@
 		can be used to approximate the step response of systems that achieve a steady state after a step input
 		\item The relative time delay $\tau_n = \tfrac{\tau}{\tau+T}$
 		has values between $0$ and $1$ and characterises the dynamics of the system
-		\item If $\tau_n$ is close to $0$ the dynamics are lag dominated, if $\tau_n$ is close to $1$ the dynamcis are delay dominated, and the dynamics are said to be balanced for intermediate values of $\tau_n$
+		\item If $\tau_n$ is close to $0$ the dynamics are lag dominated, if $\tau_n$ is close to $1$ the dynamics are delay dominated, and the dynamics are said to be balanced for intermediate values of $\tau_n$
 	\end{itemize}
 \end{frame}
 

--- a/acs-3-7-4-windup.tex
+++ b/acs-3-7-4-windup.tex
@@ -22,7 +22,7 @@
 \begin{frame}{Actuator saturation}
 \begin{itemize}
 \item We have mostly analysed control systems from the perspective of linear systems but the effects of nonlinear systems must be considered
-\item A nonlinear phenomenon of importance is saturation -- limitations in actuators such as speed limits of motors, region of movement of a robotic arm, or a valves limitations of not being more than fully opened or fully closed
+\item A nonlinear phenomenon of importance is saturation -- limitations in actuators such as speed limits of motors, region of movement of a robotic arm, or a valve's limitations of not being more than fully opened or fully closed
 \item All actuators have physical limitations
 \end{itemize}
 \end{frame}
@@ -31,7 +31,7 @@
 \begin{itemize}
 \item When saturation is achieved, the feedback loop is broken and the system effectively runs in open loop with the actuator remaining at the limiting value as long as it is still saturated
 \item In these cases, the integral term and the controller input may become very large and it may take a long time for the integrator and controller to come out of saturation
-\item This results in very large transient behaviour and is knonwn as \alert{integrator windup}
+\item This results in very large transient behaviour and is known as \alert{integrator windup}
 \item This can occur in any controller with integral action
 \end{itemize}
 \end{frame}

--- a/acs-3-7-5-implement.tex
+++ b/acs-3-7-5-implement.tex
@@ -56,11 +56,11 @@
 
 \SUBCONCEPT{Practical realisation}
 
-\begin{frame}{Analog implentation}
+\begin{frame}{Analog implementation}
 	\begin{itemize}
 		\item PID controllers may be implemented in analog hardware using operational amplifiers 
 		\item For the PI controller, $k_p=\tfrac{R_2}{R_1} $ and $k_i = \tfrac{1}{R_1C_2}$
-		\item For the PID controller, $k_p = \tfrac{R_1C_1+R_2C_2}{R_1C_2}$, $T_i = R_1C_1+R_2+C_2$, and $T_d=\tfrac{R_1R_2C_1C_2}{R_1C_1+R_2C_2}$
+		\item For the PID controller, $k_p = \tfrac{R_1C_1+R_2C_2}{R_1C_2}$, $T_i = R_1C_1+R_2C_2$, and $T_d=\tfrac{R_1R_2C_1C_2}{R_1C_1+R_2C_2}$
 	\end{itemize}
 \begin{figure}
 	\centering
@@ -70,7 +70,7 @@
 \end{figure}
 \end{frame}
 
-\begin{frame}{Digital implentation}
+\begin{frame}{Digital implementation}
 \begin{itemize}
 \item To implement a PID controller digitally onto a computer we must consider the process
 \begin{enumerate}

--- a/acs-3-8-1-sensitivity.tex
+++ b/acs-3-8-1-sensitivity.tex
@@ -102,7 +102,7 @@
 \begin{frame}{Design of controllers}
 \begin{itemize}
 	\item The Gang of Four captures the response of the system to disturbances, which assists in the design of the controller $C$
-	\item The remaining two transfer functions of the Gang of Six capture the relationship between the reference signal and hte measured output, which can be designed by $F$
+	\item The remaining two transfer functions of the Gang of Six capture the relationship between the reference signal and the measured output, which can be designed by $F$
 	\item If all of the Gang of Four transfer functions are stable, the feedback system is said to be \alert{internally stable}
 \end{itemize}
 \end{frame}

--- a/acs-3-8-2-performance.tex
+++ b/acs-3-8-2-performance.tex
@@ -99,9 +99,9 @@
 
 \begin{frame}{The sensitivity function}
 \begin{itemize}
-\item The sensitivity function $S$ shows how feedback influences the reponse of the output to both load disturbances and measurement noise
+\item The sensitivity function $S$ shows how feedback influences the response of the output to both load disturbances and measurement noise
 \item Disturbances with frequencies such that $|S(\ii\omega)|<1$ are attenuated and disturbances with frequencies with $|S(\ii\omega)|>1$ are amplified by feedback
-\item The sensitivity crossover frequency $\omega_{sc}$ is the lowest frequency where $|S(\ii\omega)=1$
+\item The sensitivity crossover frequency $\omega_{sc}$ is the lowest frequency where $|S(\ii\omega)|=1$
 \end{itemize}
 \end{frame}
 
@@ -122,7 +122,7 @@
 
 \begin{frame}{Maximum sensitivity}
 \begin{itemize}
-	\item The maximum sensitivity $M_s$ (which occurs at $\omega_{ms}$ is a measure of the largest amplification of disturbances
+	\item The maximum sensitivity $M_s$ (which occurs at $\omega_{ms}$) is a measure of the largest amplification of disturbances
 	\item It is equal to the inverse of the stability margin
 	\[M_s=\frac{1}{s_m}\]
 	\item The sensitivity crossover frequency $\omega_{sc}$ and the maximum sensitivity $M_s$ give a characterisation of load disturbance attenuation

--- a/acs-3-8-3-loopshape.tex
+++ b/acs-3-8-3-loopshape.tex
@@ -56,7 +56,7 @@ The figure below highlights a desirable shape for the loop transfer function
 
 \begin{frame}{A simple way to shape loops}
 \begin{itemize}
-\item One method for loop shaping is to start with the transfer function of the process and add simple compensaters with the transfer function
+\item One method for loop shaping is to start with the transfer function of the process and add simple compensators with the transfer function
 \[C(s)=k\frac{s+a}{s+b}, \quad a>0, b>0\]
 \item This compensator is known as a \textit{lead compensator} if $a<b$ and a \textit{lag compensator} if $a>b$
 \item As this transfer function is first-order, it can provide up to $90^\circ$ of phase lead and larger phase lead can be obtained by using a higher-order lead compensator

--- a/acs-3-8-4-rootlocus.tex
+++ b/acs-3-8-4-rootlocus.tex
@@ -97,7 +97,7 @@ and the closed loop poles are the roots of $a_{cl}(s)$
 \begin{frame}{Root locus for design}
 \begin{itemize}
 	\item Consider the previously defined transfer function $P_c(s)$ as a representation of PI control of a system with
-	\[P(s)=\frac{1}{s^2+1}, \quad C(s)=k\frac{s+2}{s}\]
+	\[P(s)=\frac{1}{s^2+1}, \quad C(s)=k\frac{s+1}{s}\]
 	\item From the root locus of $P_c(s)$, the system is unstable for all gain values and hence cannot be stabilised by PI control
 	\item PID control may be implemented by using the controller
 	\[C(s)=k\frac{s^2+2s+2}{s}\]

--- a/acs-3-9-1-uncertainmod.tex
+++ b/acs-3-9-1-uncertainmod.tex
@@ -46,7 +46,7 @@
 \begin{itemize}
 \item We may easily investigate the effects of variations in parameters but other uncertainties must also be considered
 \item For example, the cruise control system fails to account for the dynamics of the engine combustion processes, nonlinear air resistance, or delays between applying the throttle and the force at the wheels
-\item These negelected mechanisms are known as \alert{unmodeled dynamics}
+\item These neglected mechanisms are known as \alert{unmodeled dynamics}
 \item One approach is to make our model more complex but this can be challenging and often introduces more parameter uncertainty
 \item We may instead probe our system to see if it is sensitive to generic forms of unmodeled dynamics
 \end{itemize}
@@ -56,9 +56,9 @@
 \begin{frame}{Describing unmodeled dynamics}
 	\begin{itemize}
 		\item The nominal model may be augmented by a bounded input/output transfer function that captures the generic features of the unmodeled dynamics (additive $\Delta$, multiplicative $\delta$, or feedback uncertainty $\Delta_{fb}$)
-		\item These types of  are related by
+		\item These types of uncertainty are related by
 		\[\delta=\frac{\Delta}{P}, \quad \Delta_{fb} = \frac{\Delta}{P(P+\Delta)}=\frac{\delta}{P(1+\delta)}\]
-		\item If the closed loop system is stable for \textit{all}  bounded input/output transfer functions, the system is said to be robustly stable
+		\item If the closed loop system is stable for \textit{all} bounded input/output transfer functions, the system is said to be robustly stable
 		
 	\end{itemize}
 \begin{figure}

--- a/acs-3-9-2-uncertainty.tex
+++ b/acs-3-9-2-uncertainty.tex
@@ -43,7 +43,7 @@
 
 \begin{frame}{Stability bounds}
 	\begin{itemize}
-		\item Variations can be large for frequencies where $T$ is small and therefore we have the estimate of permissable perturbations
+		\item Variations can be large for frequencies where $T$ is small and therefore we have the estimate of permissible perturbations
 		\[|\delta(\ii\omega)|=\left|\frac{\Delta(\ii\omega)}{P(\ii\omega)} \right| <\frac{1}{|T(\ii\omega)|}\leq \frac{1}{M_t}\]
 		where $M_t$ is the largest value of the complementary sensitivity
 		\item This condition is quite conservative as we only need perturbations to be less than some bound in the direction of the critical point

--- a/acs-3-9-3-sysdesign.tex
+++ b/acs-3-9-3-sysdesign.tex
@@ -40,7 +40,7 @@
 	\end{itemize}
 \end{frame}
 
-\begin{frame}{Strongly stabilisability}
+\begin{frame}{Strong stabilisability}
 	\begin{itemize}
 		\item A system is strongly stabilisable if it can be stabilised by a stable controller
 		\item A linear system is strongly stabilisable if and only if it has an even number of real poles between every pair of real zeros in the right half-plane ($\operatorname{Re} s \geq 0$)
@@ -64,7 +64,7 @@
 \end{itemize}
 \end{frame}
 
-\begin{frame}{RHP zeros- Example}
+\begin{frame}{RHP zeros - Example}
 	\begin{itemize}
 		\item Consider the vehicle steering system
 		\[P(s) = \frac{av_0s+v_0^2}{bs}\]
@@ -86,12 +86,12 @@
 \end{frame}
 
 
-\begin{frame}{Time delays- Pad\'{e} approximation}
+\begin{frame}{Time delays - Pad\'{e} approximation}
 \begin{itemize}
 	\item The Pad\'{e} approximation of a time delay provides a unity gain, rational transfer function whose phase approximates the time delay
 	\item The first and second order Pad\'{e} approximations are
 	\[G_1(s)=\frac{1-s\tau/2}{1+s\tau/2}, \quad G_2(s)=\frac{1-\tau s/2 + \tau^2 s^2/12}{1+\tau s/2 + \tau^2 s^2/12}\]
-	\item The first order approximation has a right half-plane at $s=2/\tau$ and the second order approximation has a complex conjugate pair of right half-plane zeros at $s=(3\pm \ii\sqrt{3})/\tau$
+	\item The first order approximation has a right half-plane zero at $s=2/\tau$ and the second order approximation has a complex conjugate pair of right half-plane zeros at $s=(3\pm \ii\sqrt{3})/\tau$
 \end{itemize}
 \end{frame}
 

--- a/acs-3-9-4-robust.tex
+++ b/acs-3-9-4-robust.tex
@@ -94,7 +94,7 @@
 		\item These examples give us some important insight in designing robust pole placement methods
 		\item Slow stable zeros should be cancelled by controller poles to avoid peaks in the complementary sensitivity
 		\item The peaks in sensitivity of fast stable poles should be minimised by having controller zeros close to the fast poles
-		\item Slow unstable process zeros and fast unstable proces poles impose severe limits on the closed loop performance 
+		\item Slow unstable process zeros and fast unstable process poles impose severe limits on the closed loop performance 
 	\end{itemize}
 \end{frame}
 

--- a/acs-3-9-5-nonlinear.tex
+++ b/acs-3-9-5-nonlinear.tex
@@ -81,7 +81,7 @@
 	\begin{itemize}
 		\item Consider the cart-pendulum balance system with state feedback but including a friction force given by
 		\[F=-\mu_f M_t g \operatorname{sgn}(v)\]
-		\item Experiments often show that friction on the cart creates oscillaiton
+		\item Experiments often show that friction on the cart creates oscillation
 	\end{itemize}
 	
 \begin{figure}


### PR DESCRIPTION
Corrects spelling errors throughout Topics 3.7-3.9, and fixes three
mathematical issues: a garbled closed-loop characteristic polynomial
(acs-3-7-2-simple.tex), a dimensionally-inconsistent T_i formula for
the analog PID circuit (acs-3-7-5-implement.tex), and a mismatched
controller numerator in the root locus PI control example
(acs-3-8-4-rootlocus.tex).

https://claude.ai/code/session_012gAaqApiSgtP1MgTvjSxNb