### PR TITLE
Fix typos and mathematical errors in Module 2 slides

### DIFF
--- a/acs-2-4-1-reachability.tex
+++ b/acs-2-4-1-reachability.tex
@@ -34,7 +34,7 @@ where $x$ is n-dimensional
 
 \begin{frame}{Reachability}
 \begin{itemize}
-	\item A linear system is \alert{reachable} if,for any initial state $x_0$ and final state $x_f$, there exists a $T>0$ and control $u(t)$ such that $x(0)=x_0$ and $x(T)=x_f$
+	\item A linear system is \alert{reachable} if, for any initial state $x_0$ and final state $x_f$, there exists a $T>0$ and control $u(t)$ such that $x(0)=x_0$ and $x(T)=x_f$
 	\item In other words, the reachable set $\mathcal{R}(x_0,\leq T)$ is our whole state space
 	\item This is essentially saying, we can get anywhere in our state space in finite time, no matter where we start!
 \end{itemize}
@@ -64,7 +64,7 @@ where $x$ is n-dimensional
 	\begin{itemize}
 		\item Define the reachability matrix
 		\[W_r = \begin{bmatrix}
-			B & AB & A^2 B & \cdots & A^{n-1}
+			B & AB & A^2 B & \cdots & A^{n-1}B
 		\end{bmatrix}\]
 		\item A linear system is reachable if and only if the reachability matrix $W_r$ is invertible (or equivalently, full rank)
 	\end{itemize}
@@ -75,7 +75,7 @@ where $x$ is n-dimensional
 	Consider the simplified balance system (which is a model for many examples which the centre of mass is above a pivot point i.e. segway, inverted pendulum)
 	\begin{align}
 		(M+m)\ddot{p}-ml\cos \theta \ddot{\theta} &= -ml\sin\theta \dot{\theta}^2+F,\\
-		(J_ml^2)\ddot{\theta} -ml\cos \theta \ddot{p} &= mgl\sin \theta.
+		(J+ml^2)\ddot{\theta} -ml\cos \theta \ddot{p} &= mgl\sin \theta.
 	\end{align}
 	Linearising around $(p,0,0,0)$ gives us the state space matrices
 	\[ A=\begin{bmatrix}
@@ -84,7 +84,7 @@ where $x$ is n-dimensional
 		0 & m^2l^2g/\mu & 0 & 0 \\ 0& M_tmgl/\mu & 0 & 0
 	\end{bmatrix}, \quad
 	B = \begin{bmatrix}
-		0 \\ 0 \\ Jt/\mu \\ lm/\mu
+		0 \\ 0 \\ J_t/\mu \\ lm/\mu
 	\end{bmatrix}\]
 	where $\mu=M_tJ_t-m^2l^2$, $M_t=M+m$, and $J_t=J+ml^2$
 \end{frame}
@@ -99,7 +99,7 @@ The reachability matrix is
 		0 & J_t/\mu & 0 & gl^3m^3/\mu^2 \\ 
 		0 & lm/\mu & 0 & gl^2m^2M_t/\mu^2 \\
 		J_t/\mu & 0 & gl^3m^3/\mu^2 & 0 \\
-		lm/\mu & 0 & g^2l^2m^2M_t/\mu^2 & 0 
+		lm/\mu & 0 & gl^2m^2M_t/\mu^2 & 0
 	\end{bmatrix}
 \end{align}
 The determinant of this matrix is $\operatorname{det}(W_r)=-\frac{g^2l^4m^4}{\mu^6}(MJ+mJ+Mml^2)^2\neq 0$ and therefore, the reachability matrix is invertible and so the balance system is reachable!
@@ -140,7 +140,7 @@ The determinant of this matrix is $\operatorname{det}(W_r)=-\frac{g^2l^4m^4}{\mu
 	\end{bmatrix}\]
 	where $*$ are possible nonzero terms
 	\item The transformation matrix $T$ can be found by 
-	\[T=\tilde{W_r} W_r^{-1}\]
+	\[T=\tilde{W}_r W_r^{-1}\]
 \end{itemize}
 \end{frame}
 

--- a/acs-2-4-2-stabilisation.tex
+++ b/acs-2-4-2-stabilisation.tex
@@ -85,7 +85,7 @@
 
 \begin{frame}{Reachable canonical form }
 	\begin{itemize}
-		\item For control law \[u=-\tilde{K}z+k_f r=-\tilde{k}_1z_1-\tilde{k}_1z_1- \cdots - \tilde{k}_nz_n+k_fr,\] the closed loop system is 
+		\item For control law \[u=-\tilde{K}z+k_f r=-\tilde{k}_1z_1-\tilde{k}_2z_2- \cdots - \tilde{k}_nz_n+k_fr,\] the closed loop system is 
 		\[  \frac{\mathrm{d} z}{\mathrm{d} t}=\begin{bmatrix}
 			-a_1-\tilde{k}_1 & -a_2-\tilde{k}_2 & -a_3-\tilde{k}_3 & \ldots & -a_n-\tilde{k}_n \\
 			1 & 0 & & & \\
@@ -112,7 +112,7 @@
 
 \begin{frame}{Reachable canonical form}
 \begin{itemize}
-	\item Therefore, we find that relating the desired characteristic polynomial to the closed loop characterisic polynomial we have
+	\item Therefore, we find that relating the desired characteristic polynomial to the closed loop characteristic polynomial we have
 	\[\tilde{K} = \begin{bmatrix}
 		p_1-a_1 & p_2-a_2 & \cdots & p_n-a_n
 	\end{bmatrix}\]
@@ -131,7 +131,7 @@ This process allows us to assign the eigenvalues of the closed loop system to th
 	\[\operatorname{det}(sI-A) = s^n+a_1s^{n-1}+\cdots + a_{n-1}s+a_n\]
 	\item Calculate gains in reachable canonical form  
 	by determining  \[W_r = \begin{bmatrix}
-		B & AB & A^2 B & \cdots & A^{n-1}
+		B & AB & A^2 B & \cdots & A^{n-1}B
 	\end{bmatrix},\quad \tiny{\tilde{W}_r = \begin{bmatrix}
 		1 & -a_1 & a_1^2-a_2 & & \\
 		0 & 1 & -a_1 & & * \\
@@ -189,7 +189,7 @@ Choosing parameters $a=3.2$, $b=0.6$, $c=50$, $d=0.56$, $k=125$,  $r=1.6$, takin
 	\end{bmatrix} \]
 where $z_1=H-H_e$, $z_2=L-L_e$, and $v=u$
 	
-This system is reachable (by showing that the reachability matrix is full rank) and therefore we can assign the eignenvalues using state feedback
+This system is reachable (by showing that the reachability matrix is full rank) and therefore we can assign the eigenvalues using state feedback
 
 \end{frame}
 

--- a/acs-2-4-3-statedesign.tex
+++ b/acs-2-4-3-statedesign.tex
@@ -48,13 +48,13 @@ The parameter $\omega_0$ is known as the natural frequency of the system and $\z
 \begin{frame}{Second-order dynamics}
 The eigenvalues of this general system are 
 \[\lambda=-\zeta \omega_0 \pm \omega_0 \sqrt{\zeta^2-1}.\]	
-From this we can deduce that the system is stable if $\omega_0>0$ and $\zeta>0$. Also, the eigenvalues are complex if $\zeta>1$ and are real if $\zeta\leq 1$.\\
+From this we can deduce that the system is stable if $\omega_0>0$ and $\zeta>0$. Also, the eigenvalues are complex if $\zeta<1$ and are real if $\zeta\geq 1$.\\
 
 The parameter $\zeta$ describes systems that are
 \begin{itemize}
 	\item overdamped if $\zeta>1$ and exhibits exponentially decaying dynamics,
 	\item critically damped if $\zeta=1$ and gives similarly decaying dynamics, 
-	\item and is underamped if $0<\zeta < 1$ where the solutions are oscillatory with damped frequency $\omega_d=\omega_0\sqrt{1-\zeta^2}$.
+	\item and is underdamped if $0<\zeta < 1$ where the solutions are oscillatory with damped frequency $\omega_d=\omega_0\sqrt{1-\zeta^2}$.
 \end{itemize}
 \end{frame}
 

--- a/acs-2-4-4-integral.tex
+++ b/acs-2-4-4-integral.tex
@@ -60,7 +60,7 @@ b \\ 0
 0 \\ v_e-v_r
 \end{bmatrix}\]
 in state space.\\
-The constants $a$, $b$, $b_g$ depend on properties of the system, $x=v-v_e$ is the speed around the equilibrium, $w=u-u_e$ is the throttle around the equilibrium , and $\theta$ is the angle of the road.
+The constants $a$, $b$, $b_g$ depend on properties of the system, $x=v-v_e$ is the speed around the equilibrium, $w=u-u_e$ is the throttle around the equilibrium, and $\theta$ is the angle of the road.
 \end{frame}
 
 \begin{frame}{Example continued}

--- a/acs-2-5-1-freq.tex
+++ b/acs-2-5-1-freq.tex
@@ -57,7 +57,7 @@ where $\omega_f$ is the \emph{fundamental frequency} of the periodic input (i.e.
 G(\ii\ww) &= C(\ii\ww I - A)^{-1}B + D = M\ee^{\ii\theta}
 \end{align}
 where we set $\ww=k \omega_f$ for $k=0,1,2,\dots$
-\item See Topic 3.4 / \AMref*{§6.3}
+\item See Topic 2.4 / \AMref*{§6.3}
 \item \alert{This equation generalises for complex exponential inputs as well: $u(t) = \ee^{st}$:
 \begin{align}
 G(s) &= C(s I - A)^{-1}B + D = M\ee^{\ii\theta}

--- a/acs-2-5-2-tf.tex
+++ b/acs-2-5-2-tf.tex
@@ -29,7 +29,7 @@
 \ee^{(\sigma+\ii\ww)t} = \ee^{\sigma t}\ee^{\ii\ww t} = \ee^{\alpha t}\left( \cos\ww t + \ii \sin \ww t \right)
 \end{align}
 \begin{itemize}
-\item This signal allows use to representing growth/decay and/or oscillation
+\item This signal allows us to represent growth/decay and/or oscillation
 \end{itemize}
 \end{frame}
 

--- a/acs-2-5-3-laplace.tex
+++ b/acs-2-5-3-laplace.tex
@@ -96,7 +96,7 @@ Consider exponential $f(t)=\Exp{-at}$:
   s &= \sigma+\jj\ww \qquad (\jj^2=-1) \\
   \mathcal{L}\bigl\{f(t)\bigr\} &= F(s) \\
   \mathcal{L}\bigl\{\Deriv{}{t}f(t)\bigr\} &= sF(s)  \\
-  \mathcal{L}\bigr\{\int f(t)\dee t\bigr\} &= \frac{1}{s}F(s)
+  \mathcal{L}\bigl\{\int f(t)\dee t\bigr\} &= \frac{1}{s}F(s)
   \end{align}
   Note, in control, we always linearise our systems around an equilibrium and can therefore ignore initial conditions $f(0)$
 \end{frame}

--- a/acs-2-5-5-dc.tex
+++ b/acs-2-5-5-dc.tex
@@ -12,7 +12,7 @@
 \end{itemize}
 \vfill References:
 \begin{itemize}
-\item \astrom{Chapter Z}
+\item \astrom{§9.5}
 \end{itemize}
 \end{SUMMARY}
 
@@ -99,7 +99,7 @@ For TF $G(s) = b(s)/a(s)$ with polynomials $b(s)$ and $a(s)$:
 \begin{uncoverenv}<2->
 Consider:
 \begin{align}
-P(s) &= \frac{s-1}{s^2+6s+s} & C(s) &= \frac{s+1}{(s-1)(s+2)}
+P(s) &= \frac{s-1}{s^2+6s+5} & C(s) &= \frac{s+1}{(s-1)(s+2)}
 \end{align}
 \end{uncoverenv}
 

--- a/acs-2-5-6-bode.tex
+++ b/acs-2-5-6-bode.tex
@@ -159,7 +159,7 @@ where
 \item $N_P =$ number of poles\\ (incl.\ integrators)
 \item $N_Z =$ number of zeros\\ (incl.\ differentiators)
 \end{itemize}
-$n_{pe} = (N_P-N_Z)$ is used often and termed the `poles excess'
+$n_{pe} = (N_P-N_Z)$ is used often and termed the `pole excess'
 
 
 \end{columns}

--- a/acs-2-6-2-nyq.tex
+++ b/acs-2-6-2-nyq.tex
@@ -24,7 +24,7 @@
 \item The dynamics of a linear system may be represented by its frequency response and graphically illustrated by a Bode plot
 \item We may also graphically represent the frequency response on one graph by using a Nyquist plot, plotted on the complex plane
 \item The Nyquist plot of a loop transfer function $L(s)$ is formed by tracing $s\in\mathbb{C}$ around the Nyquist contour $\Gamma$ (given by the imaginary axis combined with an arc at infinity connecting the endpoints of the imaginary axis)
-\item At any point on the Nyquist plot corresponding to a frequency $s=\jj\omega$, the distance away from the origin gives the magnitude of the loop transfer function $L(s)$ and the angle with the imaginary axis gives the phase
+\item At any point on the Nyquist plot corresponding to a frequency $s=\jj\omega$, the distance away from the origin gives the magnitude of the loop transfer function $L(s)$ and the angle with the positive real axis gives the phase
 \end{itemize}
 \end{frame}
 
@@ -43,7 +43,7 @@
 
 \begin{frame}{Condition for stability - Nyquist criterion}
 \begin{itemize}
-\item Let $L(s)$ be the loop transfer function for a negative feedback system and assume that $L$ has no poles in the closed right half-plane expect possible at the origin
+\item Let $L(s)$ be the loop transfer function for a negative feedback system and assume that $L$ has no poles in the closed right half-plane except possibly at the origin
 \item Then the closed loop system 
 \[
 G_{cl}=\frac{L(s)}{1+L(s)}

--- a/acs-2-6-3-stabmarg.tex
+++ b/acs-2-6-3-stabmarg.tex
@@ -47,7 +47,7 @@ The gain and phase margins may also be determined from the Bode plots
 \begin{itemize}
 	\item The \alert{stability margin} $s_m$ is determined by finding the closest point on the Nyquist curve to the critical point and calculating this distance
 	\item The \alert{gain margin} $g_m$ is the inverse of the distance between the origin and the point between $-1$ and $0$ where the loop transfer function crosses the negative real axis
-	\item The \alert{phase margin} $\varphi_m$ is the angle between the the negative real axis and the line joining the origin with the point where the loop transfer function intersects the unit circle below the real axis
+	\item The \alert{phase margin} $\varphi_m$ is the angle between the negative real axis and the line joining the origin with the point where the loop transfer function intersects the unit circle below the real axis
 \end{itemize}
 \end{frame}
 
@@ -64,7 +64,7 @@ The gain and phase margins may also be determined from the Bode plots
 \begin{frame}{Example}
 \begin{itemize}
 	\item Consider the loop transfer function $L=\tfrac{3}{(s+1)^3}$
-	\item From the Nyquist plot we get $s_m=0.464$, $g_m = 2.67$, $\varphi=41.7^\circ$
+	\item From the Nyquist plot we get $s_m=0.464$, $g_m = 2.67$, $\varphi_m=41.7^\circ$
 \end{itemize}
 \begin{figure}
 	\centering

--- a/acs-2-6-4-minphase.tex
+++ b/acs-2-6-4-minphase.tex
@@ -69,7 +69,7 @@ where $f$ is the weighting kernel $f(\omega)=\frac{2}{\pi^2} \log \left|\frac{\o
 \begin{frame}{Example}
 \begin{itemize}
 	\item The transfer function $G(s)=\frac{a-s}{a+s}$ with $a>0$ has a zero $s=a$ in the right half-plane, with unit gain $|G(\jj\omega)|=1$ and phase curve given by $\operatorname{arg} G(\jj\omega) = -2\arctan (\tfrac{\omega}{a})$
-	\item The transfer function $G(s)=\frac{s+a}{s-a}$ with $a>0$ has a pole in the right half-plane, has unit gain $|G(\jj\omega)|=1$ and phase  $\operatorname{arg} G(\jj\omega) = -2\arctan (\tfrac{\omega}{a})$
+	\item The transfer function $G(s)=\frac{s+a}{s-a}$ with $a>0$ has a pole in the right half-plane, has unit gain $|G(\jj\omega)|=1$ and phase  $\operatorname{arg} G(\jj\omega) = 2\arctan (\tfrac{\omega}{a}) - \pi$
 	\item The corresponding minimum phase system is the transfer function $G(s)=1$
 \end{itemize}
 \end{frame}


### PR DESCRIPTION
## Summary

Review of Module 2 (Topics 2.4–2.6) Beamer slides for typos, clarity, and mathematical correctness.

**Topic 2.4 (State Feedback/Observers)**
- Missing `B` in the reachability matrix formula `[B, AB, ..., A^{n-1}]` → `[B, AB, ..., A^{n-1}B]` (two files)
- `(J_ml^2)` → `(J+ml^2)` in the linearised pendulum dynamics
- Missing subscript `Jt/\mu` → `J_t/\mu`
- Extra factor of `g` in a $W_r$ reachability matrix entry (verified by derivation)
- `\tilde{W_r}` → `\tilde{W}_r` (tilde macro was misplaced)
- Duplicated gain term `\tilde{k}_1z_1` → `\tilde{k}_2z_2`
- Backwards eigenvalue/damping statement: `$\zeta>1$`↔complex and `$\zeta\le1$`↔real were swapped, contradicting the following paragraph
- Spelling: "characterisic" → "characteristic", "eignenvalues" → "eigenvalues", "underamped" → "underdamped", plus minor spacing fixes

**Topic 2.5 (Frequency Domain/Transfer Functions)**
- Stale "Topic 3.4" cross-reference → "Topic 2.4"
- Placeholder `\astrom{Chapter Z}` → `\astrom{§9.5}`
- Denominator typo `s^2+6s+s` → `s^2+6s+5` (inconsistent with its own use two lines later)
- Mismatched `\bigr\{`/`\bigl\{` delimiter
- "poles excess" → "pole excess"
- Grammar fix: "allows use to representing" → "allows us to represent"

**Topic 2.6 (Stability/Nyquist)**
- "expect possible" → "except possibly"
- "angle with the imaginary axis" → "angle with the positive real axis" (Nyquist phase convention)
- Duplicated "the the"
- `$\varphi$` → `$\varphi_m$` (notation consistency)
- Corrected RHP-pole phase formula, which had duplicated the RHP-zero formula (verified by derivation: should be `2\arctan(\omega/a)-\pi`, not `-2\arctan(\omega/a)`)

## Test plan
- [ ] CI (`make all`) compiles cleanly

https://claude.ai/code/session_012gAaqApiSgtP1MgTvjSxNb

---
_Generated by [Claude Code](https://claude.ai/code/session_012gAaqApiSgtP1MgTvjSxNb)_